### PR TITLE
Remove absolute path to coap-client

### DIFF
--- a/pytradfri/coap_cli.py
+++ b/pytradfri/coap_cli.py
@@ -21,7 +21,7 @@ def api_factory(host, security_code):
         command_string = 'coaps://{}:5684/{}'.format(host, path)
 
         command = [
-            '/usr/local/bin/coap-client',
+            'coap-client',
             '-u',
             'Client_identity',
             '-k',


### PR DESCRIPTION
Most linux distribution (including the dev Docker container) have /usr/local/bin configured in their PATH.
Plus removing the absolute path also allows users to have coap-client installed in a different location without having to update the source code to reflect this change.