### PR TITLE
Disable coap-client debug output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ cd libcoap
 $ git checkout dtls
 $ git submodule update --init --recursive
 $ ./autogen.sh
-$ ./configure --disable-documentation --disable-shared
+$ ./configure --disable-documentation --disable-shared --without-debug CFLAGS="-D COAP_DEBUG_FD=stderr"
 $ make
 $ sudo make install
 ```

--- a/pytradfri/coap_cli.py
+++ b/pytradfri/coap_cli.py
@@ -35,7 +35,7 @@ def api_factory(host, security_code):
 
         kwargs = {
             'timeout': timeout,
-            'stderr': subprocess.STDOUT,
+            'stderr': subprocess.DEVNULL,
         }
 
         if data is not None:
@@ -48,21 +48,13 @@ def api_factory(host, security_code):
 
         try:
             return_value = subprocess.check_output(command, **kwargs)
-            out = return_value.strip().decode('utf-8')
+            output = return_value.strip().decode('utf-8')
         except subprocess.TimeoutExpired:
             raise RequestTimeout() from None
         except subprocess.CalledProcessError as err:
             raise RequestError(
                 'Error executing request: %s'.format(err)) from None
 
-        # Return only the last line, where there's JSON
-        lines = [line for line in out.split('\n')[1:]
-                 if 'decrypt_verify' not in line]
-
-        if not lines:
-            return None
-
-        output = lines[0]
         _LOGGER.debug('Received: %s', output)
 
         if output.startswith(CLIENT_ERROR_PREFIX):

--- a/pytradfri/coap_cli.py
+++ b/pytradfri/coap_cli.py
@@ -57,7 +57,16 @@ def api_factory(host, security_code):
 
         _LOGGER.debug('Received: %s', output)
 
-        if output.startswith(CLIENT_ERROR_PREFIX):
+        if not output:
+            return None
+
+        elif 'decrypt_verify' in output:
+            raise RequestError(
+                'Please compile coap-client without debug output. See '
+                'instructions at '
+                'https://github.com/ggravlingen/pytradfri#installation')
+
+        elif output.startswith(CLIENT_ERROR_PREFIX):
             raise ClientError(output)
 
         elif output.startswith(SERVER_ERROR_PREFIX):

--- a/script/install-coap-client.sh
+++ b/script/install-coap-client.sh
@@ -2,6 +2,6 @@
 git clone --depth 1 --recursive -b dtls https://github.com/home-assistant/libcoap.git
 cd libcoap
 ./autogen.sh
-./configure --disable-documentation --disable-shared
+./configure --disable-documentation --disable-shared --without-debug CFLAGS="-D COAP_DEBUG_FD=stderr"
 make
 make install


### PR DESCRIPTION
Prevent coap-client from outputting annoying debug output to stdout, which we need to filter out afterwards.
Using some autoconf magic ensures no modifications to the coap source code are made.
This might also be useful for #2, as coap-client now provides a clean json stream when subscribed.