### PR TITLE
Removed identity since it's not needed

### DIFF
--- a/pytradfri/coap_cli.py
+++ b/pytradfri/coap_cli.py
@@ -22,8 +22,6 @@ def api_factory(host, security_code):
 
         command = [
             'coap-client',
-            '-u',
-            'Client_identity',
             '-k',
             security_code,
             '-v',


### PR DESCRIPTION
I noticed that the identity (-u user) property is not needed when using the coap-client so I removed it.

In fact it seems advised to actually not use it according to [this article](https://bitsex.net/software/2017/coap-endpoints-on-ikea-tradfri/)
 >   UPDATE: Leave PSK identity blank.