### PR TITLE
patch for macos

### DIFF
--- a/pytradfri/coap_cli.py
+++ b/pytradfri/coap_cli.py
@@ -38,8 +38,22 @@ def api_factory(host, security_code):
 
         if data is not None:
             kwargs['input'] = json.dumps(data).encode('utf-8')
-            command.append('-f')
-            command.append('-')
+#            command.append('-f')
+#            command.append('-')
+            command = [
+                'coap-client',
+                '-f',
+                '-',
+                '-u',
+                'Client_identity',
+                '-k',
+                security_code,
+                '-v',
+                '0',
+                '-m',
+                method,
+                command_string
+            ]
             _LOGGER.debug('Executing %s %s %s: %s', host, method, path, data)
         else:
             _LOGGER.debug('Executing %s %s %s', host, method, path)


### PR DESCRIPTION
i think i found out what was causing the problems on macos (see #14). actually ´coap-client´ compiles just fine on macos, what prevented it from working without a 4.00 client error, was appending the `-f -`. this will throw a client error, for whatever reason. if i call

`echo '{ "3311" : [{ "5851" : 20 }] }' | coap-client  -f - -u "Client_identity" -k "xxx" -m put "coaps://192.168.1.68:5684/15001/65539"`

everthing works fine on macos.

i patched coap_cli.py rather clumsily, but this makes pytradfri work on macos. i’m sure you’ll find a more elegant way to reflect that macos peculiarity.