### PR TITLE
Add support for observing resources.

### DIFF
--- a/pytradfri/coap_cli.py
+++ b/pytradfri/coap_cli.py
@@ -14,68 +14,114 @@ SERVER_ERROR_PREFIX = '5.'
 
 def api_factory(host, security_code):
     """Generate a request method."""
-    def request(method, path, data=None, *, parse_json=True, timeout=10):
-        """Make a request."""
-
-        path = '/'.join(str(v) for v in path)
-        command_string = 'coaps://{}:5684/{}'.format(host, path)
-
-        command = [
+    def base_command(method):
+        """Return base commmand."""
+        return [
             'coap-client',
             '-k',
             security_code,
             '-v',
             '0',
             '-m',
-            method,
-            command_string
+            method
         ]
 
+    def url(path):
+        """Generate url for coap client."""
+        path = '/'.join(str(v) for v in path)
+        return 'coaps://{}:5684/{}'.format(host, path)
+
+    def request(method, path, data=None, *, parse_json=True, timeout=10):
+        """Make a request."""
+        command = base_command(method)
+
         kwargs = {
-            'timeout': timeout,
             'stderr': subprocess.DEVNULL,
+            'timeout': timeout,
+            'universal_newlines': True,
         }
 
         if data is not None:
-            kwargs['input'] = json.dumps(data).encode('utf-8')
-            command.insert(1, '-f')
-            command.insert(2, '-')
+            kwargs['input'] = json.dumps(data)
+            command.append('-f')
+            command.append('-')
             _LOGGER.debug('Executing %s %s %s: %s', host, method, path, data)
         else:
             _LOGGER.debug('Executing %s %s %s', host, method, path)
 
+        command.append(url(path))
+
         try:
             return_value = subprocess.check_output(command, **kwargs)
-            output = return_value.strip().decode('utf-8')
         except subprocess.TimeoutExpired:
             raise RequestTimeout() from None
         except subprocess.CalledProcessError as err:
             raise RequestError(
                 'Error executing request: %s'.format(err)) from None
 
-        _LOGGER.debug('Received: %s', output)
+        return _process_output(return_value.strip(), parse_json)
 
-        if not output:
-            return None
-
-        elif 'decrypt_verify' in output:
+    def observe(path, callback, time):
+        """Observe an endpoint."""
+        command = base_command('get') + ['-s', str(time), url(path)]
+        kwargs = {
+            'stdout': subprocess.PIPE,
+            'stderr': subprocess.DEVNULL,
+            'universal_newlines': True
+        }
+        try:
+            proc = subprocess.Popen(command, **kwargs)
+        except subprocess.CalledProcessError as err:
             raise RequestError(
-                'Please compile coap-client without debug output. See '
-                'instructions at '
-                'https://github.com/ggravlingen/pytradfri#installation')
+                'Error executing request: %s'.format(err)) from None
 
-        elif output.startswith(CLIENT_ERROR_PREFIX):
-            raise ClientError(output)
+        output = ''
+        open_obj = 0
+        in_string = False
+        for data in iter(lambda: proc.stdout.read(1), ''):
+            output += data
 
-        elif output.startswith(SERVER_ERROR_PREFIX):
-            raise ServerError(output)
+            if data == '"':
+                in_string = not in_string
+            elif in_string:
+                pass
+            elif data == '{':
+                open_obj += 1
+            elif data == '}':
+                open_obj -= 1
 
-        elif not parse_json:
-            return output
+            if open_obj == 0:
+                callback(_process_output(output))
+                output = ''
 
-        return json.loads(output)
+    request.observe = observe
 
     # This will cause a RequestError to be raised if credentials invalid
     request('get', ['status'])
 
     return request
+
+
+def _process_output(output, parse_json=True):
+    """Process output."""
+    _LOGGER.debug('Received: %s', output)
+
+    if not output:
+        return None
+
+    elif 'decrypt_verify' in output:
+        raise RequestError(
+            'Please compile coap-client without debug output. See '
+            'instructions at '
+            'https://github.com/ggravlingen/pytradfri#installation')
+
+    elif output.startswith(CLIENT_ERROR_PREFIX):
+        raise ClientError(output)
+
+    elif output.startswith(SERVER_ERROR_PREFIX):
+        raise ServerError(output)
+
+    elif not parse_json:
+        return output
+
+    return json.loads(output)

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -6,8 +6,6 @@ from .const import (
     ATTR_APPLICATION_TYPE,
     ATTR_DEVICE_INFO,
     ATTR_NAME,
-    ATTR_CREATED_AT,
-    ATTR_ID,
     ATTR_REACHABLE_STATE,
     ATTR_LAST_SEEN,
     ATTR_LIGHT_CONTROL,
@@ -17,26 +15,15 @@ from .const import (
     ATTR_LIGHT_COLOR_Y,
     ATTR_LIGHT_COLOR
 )
+from .resource import ApiResource
 
 
-class Device(object):
+class Device(ApiResource):
     """Base class for devices."""
-
-    def __init__(self, api, raw):
-        self.api = api
-        self.raw = raw
-
-    @property
-    def id(self):
-        return self.raw.get(ATTR_ID)
 
     @property
     def application_type(self):
         return self.raw.get(ATTR_APPLICATION_TYPE)
-
-    @property
-    def name(self):
-        return self.raw.get(ATTR_NAME)
 
     @property
     def path(self):
@@ -45,12 +32,6 @@ class Device(object):
     @property
     def device_info(self):
         return DeviceInfo(self)
-
-    @property
-    def created_at(self):
-        if ATTR_CREATED_AT not in self.raw:
-            return None
-        return datetime.utcfromtimestamp(self.raw[ATTR_CREATED_AT])
 
     @property
     def last_seen(self):
@@ -76,22 +57,6 @@ class Device(object):
         self.set_values({
             ATTR_NAME: name
         })
-
-    def observe(self, callback, time=100):
-        """Observe device and call callback when device updated."""
-        def observe_callback(value):
-            """Called when end point is updated."""
-            self.raw = value
-            callback(self)
-
-        self.api.observe(self.path, observe_callback, time)
-
-    def set_values(self, values):
-        """Helper to set values for device."""
-        self.api('put', self.path, values)
-
-    def update(self):
-        self.raw = self.api('get', self.path)
 
     def __repr__(self):
         return "<{} - {} ({})>".format(self.id, self.name,

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -5,7 +5,6 @@ from .const import (
     ROOT_DEVICES,
     ATTR_APPLICATION_TYPE,
     ATTR_DEVICE_INFO,
-    ATTR_NAME,
     ATTR_REACHABLE_STATE,
     ATTR_LAST_SEEN,
     ATTR_LIGHT_CONTROL,
@@ -51,12 +50,6 @@ class Device(ApiResource):
     @property
     def light_control(self):
         return LightControl(self)
-
-    def set_name(self, name):
-        """Set group name."""
-        self.set_values({
-            ATTR_NAME: name
-        })
 
     def __repr__(self):
         return "<{} - {} ({})>".format(self.id, self.name,

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -77,6 +77,15 @@ class Device(object):
             ATTR_NAME: name
         })
 
+    def observe(self, callback, time=100):
+        """Observe device and call callback when device updated."""
+        def observe_callback(value):
+            """Called when end point is updated."""
+            self.raw = value
+            callback(self)
+
+        self.api.observe(self.path, observe_callback, time)
+
     def set_values(self, values):
         """Helper to set values for device."""
         self.api('put', self.path, values)

--- a/pytradfri/group.py
+++ b/pytradfri/group.py
@@ -1,39 +1,22 @@
-from datetime import datetime
-
 from .const import (
     ROOT_GROUPS,
     ATTR_LIGHT_STATE,
     ATTR_LIGHT_DIMMER,
     ATTR_NAME,
-    ATTR_CREATED_AT,
     ATTR_ID,
 )
+from .resource import ApiResource
 
 ROOT_DEVICES2 = "15002"  # ??
 ATTR_MEMBERS = "9018"
 ATTR_MOOD = "9039"
 
 
-class Group:
+class Group(ApiResource):
     """Represent a group."""
     def __init__(self, gateway, raw):
+        super().__init__(gateway.api, raw)
         self._gateway = gateway
-        self.api = gateway.api
-        self.raw = raw
-
-    @property
-    def id(self):
-        return self.raw.get(ATTR_ID)
-
-    @property
-    def name(self):
-        return self.raw.get(ATTR_NAME)
-
-    @property
-    def created_at(self):
-        if ATTR_CREATED_AT not in self.raw:
-            return None
-        return datetime.utcfromtimestamp(self.raw[ATTR_CREATED_AT])
 
     @property
     def path(self):
@@ -83,14 +66,6 @@ class Group:
         self.set_values({
             ATTR_NAME: name
         })
-
-    def set_values(self, values):
-        """Helper to set values for group."""
-        self.api('put', self.path, values)
-
-    def update(self):
-        """Update the group."""
-        self.raw = self.api('get', self.path)
 
     def __repr__(self):
         state = 'on' if self.state else 'off'

--- a/pytradfri/group.py
+++ b/pytradfri/group.py
@@ -2,7 +2,6 @@ from .const import (
     ROOT_GROUPS,
     ATTR_LIGHT_STATE,
     ATTR_LIGHT_DIMMER,
-    ATTR_NAME,
     ATTR_ID,
 )
 from .resource import ApiResource
@@ -61,10 +60,19 @@ class Group(ApiResource):
             ATTR_MOOD: mood_id
         })
 
-    def set_name(self, name):
-        """Set group name."""
+    def set_state(self, state):
+        """Set state of a group."""
         self.set_values({
-            ATTR_NAME: name
+            ATTR_LIGHT_STATE: int(state)
+        })
+
+    def set_dimmer(self, dimmer):
+        """Set dimmer value of a group.
+
+        Integer between 0..255
+        """
+        self.set_values({
+            ATTR_LIGHT_DIMMER: dimmer,
         })
 
     def __repr__(self):

--- a/pytradfri/mood.py
+++ b/pytradfri/mood.py
@@ -1,40 +1,16 @@
 """Represent a mood on the gateway."""
-from datetime import datetime
-
-from .const import (
-    ROOT_MOODS, ATTR_ID, ATTR_NAME, ATTR_CREATED_AT)
+from .const import ROOT_MOODS
+from .resource import ApiResource
 
 
-class Mood:
+class Mood(ApiResource):
     def __init__(self, api, raw, parent):
-        self.api = api
-        self.raw = raw
+        super().__init__(api, raw)
         self._parent = parent
-
-    @property
-    def id(self):
-        return self.raw.get(ATTR_ID)
-
-    @property
-    def name(self):
-        return self.raw.get(ATTR_NAME)
-
-    @property
-    def created_at(self):
-        if ATTR_CREATED_AT not in self.raw:
-            return None
-        return datetime.utcfromtimestamp(self.raw[ATTR_CREATED_AT])
 
     @property
     def path(self):
         return [ROOT_MOODS, self._parent, self.id]
-
-    def set_values(self, values):
-        """Helper to set values for mood."""
-        self.api('put', self.path, values)
-
-    def update(self):
-        self.raw = self.api('get', self.path)
 
     def __repr__(self):
         return '<Mood {}>'.format(self.name)

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -34,14 +34,14 @@ class ApiResource:
         """Path to resource."""
         raise NotImplemented('Path property needs to be implemented')
 
-    def observe(self, callback, time=100):
+    def observe(self, callback, duration=60):
         """Observe resource and call callback when updated."""
         def observe_callback(value):
             """Called when end point is updated."""
             self.raw = value
             callback(self)
 
-        self.api.observe(self.path, observe_callback, time)
+        self.api.observe(self.path, observe_callback, duration)
 
     def set_name(self, name):
         """Set group name."""

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+
+from .const import (
+    ATTR_NAME,
+    ATTR_CREATED_AT,
+    ATTR_ID,
+)
+
+
+class ApiResource:
+    """Base object for resources returned from the gateway."""
+
+    def __init__(self, api, raw):
+        """Initialize base object."""
+        self.api = api
+        self.raw = raw
+
+    @property
+    def id(self):
+        return self.raw.get(ATTR_ID)
+
+    @property
+    def name(self):
+        return self.raw.get(ATTR_NAME)
+
+    @property
+    def created_at(self):
+        if ATTR_CREATED_AT not in self.raw:
+            return None
+        return datetime.utcfromtimestamp(self.raw[ATTR_CREATED_AT])
+
+    @property
+    def path(self):
+        """Path to resource."""
+        raise NotImplemented('Path property needs to be implemented')
+
+    def observe(self, callback, time=100):
+        """Observe resource and call callback when updated."""
+        def observe_callback(value):
+            """Called when end point is updated."""
+            self.raw = value
+            callback(self)
+
+        self.api.observe(self.path, observe_callback, time)
+
+    def set_values(self, values):
+        """Helper to set values for group."""
+        self.api('put', self.path, values)
+
+    def update(self):
+        """Update the group."""
+        self.raw = self.api('get', self.path)

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -43,6 +43,12 @@ class ApiResource:
 
         self.api.observe(self.path, observe_callback, time)
 
+    def set_name(self, name):
+        """Set group name."""
+        self.set_values({
+            ATTR_NAME: name
+        })
+
     def set_values(self, values):
         """Helper to set values for group."""
         self.api('put', self.path, values)


### PR DESCRIPTION
This adds support for observing devices. I did shuffle some arguments around (related to #17 and #19). I think that the problem is related to having the arguments be after the url.

Returned API object now has a new method `observe`. Call it with a path, time to observe and a callback.

I've added support to this for devices, so that you can observe a device, which will update and then call your callback.

```python
def beer(device):
  print(device.name + " is now " + str(device.light_control.lights[0].state))

lights[0].observe(beer)
```

**Update:** generalized the code so that now we can observe groups and moods too.
**Update 2:** Added `set_dimmer` and `set_state` to the group object.