### PR TITLE
Allow aiocoap experimentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,14 @@ RUN apt-get update -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* build/
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+RUN mkdir -p /usr/src/app /usr/src/build
+WORKDIR /usr/src/build
 
 COPY ./script/install-coap-client.sh install-coap-client.sh
 RUN ./install-coap-client.sh
 
+COPY ./script/install-aiocoap.sh install-aiocoap.sh
+RUN ./install-aiocoap.sh
+
+WORKDIR /usr/src/app
 CMD /bin/bash

--- a/script/aiotry.py
+++ b/script/aiotry.py
@@ -1,0 +1,25 @@
+import asyncio
+import sys
+
+sys.path.insert(0, '/usr/src/build/tinydtls/cython')
+
+from aiocoap import Message, Context, GET  # noqa
+from aiocoap.transports.tinydtls import PSK_STORE  # noqa
+
+
+@asyncio.coroutine
+def main():
+    if len(sys.argv) < 2:
+        print("Pass in key as second argument")
+        return
+
+    PSK_STORE[b'Client_identity'] = sys.argv[1].encode('utf-8')
+
+    msg = Message(code=GET, uri="coaps://192.168.1.19:5684/15001")
+    protocol = yield from Context.create_client_context()
+    res = yield from protocol.request(msg).response
+    print("RECEIVED STATUS", res.code)
+    print("RECEIVED PAYLOAD", res.payload.decode('utf-8'))
+
+
+asyncio.get_event_loop().run_until_complete(main())

--- a/script/install-aiocoap.sh
+++ b/script/install-aiocoap.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+git clone --depth 1 https://git.fslab.de/jkonra2m/tinydtls
+cd tinydtls
+autoreconf
+./configure --with-ecc
+make
+cd cython
+pip3 install cython
+python3 setup.py build_ext --inplace
+
+cd ../..
+git clone --depth 1 -b patch-1 https://github.com/balloob/aiocoap/
+cd aiocoap
+python3 setup.py develop


### PR DESCRIPTION
This updates our Dockerfile to allow experimentation with aiocoap. Aiocoap is a pure Python implementation based on asyncio. This would mean we no longer have to depend on calling a process to communicate with IKEA.

This branch contains support for getting the right branch of aiocoap working + the cython bindings for tinydtls. I've included a small demo script in the scripts dir for now to show that it works.

```python
script/dev_docker
[ in docker shell ]
cd script
python3 aiotry.py <IKEA KEY>
```

That will give you an output like this:

```
root@moby:/usr/src/app/script# python3 aiotry.py SECRETKEY
decrypt_verify(): found 24 bytes cleartext
decrypt_verify(): found 46 bytes cleartext
RECEIVED STATUS 2.05 Content
RECEIVED PAYLOAD [65536,65537,65538,65539,65540]
Exception ignored in: 'dtls._write'
Traceback (most recent call last):
  File "/usr/src/build/aiocoap/aiocoap/transports/tinydtls.py", line 117, in _write
AttributeError: 'DTLSClientConnection' object has no attribute '_transport'
```