### PR TITLE
Split coap-client output on newline.

### DIFF
--- a/pytradfri/coap_cli.py
+++ b/pytradfri/coap_cli.py
@@ -128,5 +128,7 @@ def _process_output(output, parse_json=True):
 
     elif not parse_json:
         return output
-
+    if len(output.split('\n')) == 2:
+        output = output.split('\n')[1]
+        _LOGGER.debug('Output after splitting: %s', output)
     return json.loads(output)


### PR DESCRIPTION
With coap-client v4.1.2  the output can not be blindly parsed as json.
Example output:
```
v:1 t:CON c:GET i:6697 {} [ ]
{}
```
Splitting on newline and using the 2nd part/line seems to solve that issue.