### PR TITLE
Support for wrapping API requests

### DIFF
--- a/pytradfri/api.py
+++ b/pytradfri/api.py
@@ -1,10 +1,12 @@
 """API utilities."""
+from functools import wraps
 
 from .error import RequestTimeout
 
 
 def retry_timeout(api, retries=3):
     """Retry API call when a timeout occurs."""
+    @wraps(api)
     def retry_api(*args, **kwargs):
         """Retrying API."""
         for i in range(1, retries + 1):


### PR DESCRIPTION
If you wrap the func, you can't get access to `observe`. I was debating on whether or not this should have been a class?