### PR TITLE
Cache protocol for better performance, and to fix observation issues

### DIFF
--- a/example_async.py
+++ b/example_async.py
@@ -61,12 +61,13 @@ def run():
     def observe_err_callback(err):
         print('observe error:', err)
 
-    observe_command = light.observe(observe_callback, observe_err_callback,
-                                    duration=120)
-    # Start observation as a second task on the loop.
-    observe_future = ensure_future(api(observe_command))
-    # Yield to allow observing to start.
-    yield from asyncio.sleep(0)
+    for light in lights:
+        observe_command = light.observe(observe_callback, observe_err_callback,
+                                        duration=120)
+        # Start observation as a second task on the loop.
+        ensure_future(api(observe_command))
+        # Yield to allow observing to start.
+        yield from asyncio.sleep(0)
 
     # Example 1: checks state of the light 2 (true=on)
     print("Is on:", light.light_control.lights[0].state)
@@ -96,9 +97,8 @@ def run():
         yield from api(dim_command_2)
 
     print("Waiting for observation to end (2 mins)")
-    print("Try altering the light (%s) in the app, and watch the events!" %
-          light.name)
-    yield from observe_future
+    print("Try altering any light in the app, and watch the events!")
+    yield from asyncio.sleep(120)
 
 
 asyncio.get_event_loop().run_until_complete(run())

--- a/example_async.py
+++ b/example_async.py
@@ -69,20 +69,20 @@ def run():
         # Yield to allow observing to start.
         yield from asyncio.sleep(0)
 
-    # Example 1: checks state of the light 2 (true=on)
+    # Example 1: checks state of the light 0 (true=on)
     print("Is on:", light.light_control.lights[0].state)
 
-    # Example 2: get dimmer level of light 2
+    # Example 2: get dimmer level of light 0
     print("Dimmer:", light.light_control.lights[0].dimmer)
 
-    # Example 3: What is the name of light 2
+    # Example 3: What is the name of light 0
     print("Name:", light.name)
 
-    # Example 4: Set the light level of light 2
+    # Example 4: Set the light level of light 0
     dim_command = light.light_control.set_dimmer(255)
     yield from api(dim_command)
 
-    # Example 5: Change color of light 2
+    # Example 5: Change color of light 0
     # f5faf6 = cold | f1e0b5 = normal | efd275 = warm
     color_command = light.light_control.set_hex_color('efd275')
     yield from api(color_command)

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -58,6 +58,7 @@ def api_factory(host, security_code, loop=None):
         """Reset the protocol if an error occurs.
            This can be removed when chrysn/aiocoap#79 is closed."""
         # Be responsible and clean up.
+        protocol = yield from _get_protocol()
         yield from protocol.shutdown()
         nonlocal _protocol
         _protocol = None

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -55,14 +55,13 @@ def api_factory(host, security_code, loop=None):
 
     @asyncio.coroutine
     def _reset_protocol(exc):
-        """Reset the protocol if an error occurs."""
-        protocol = yield from _get_protocol()
+        """Reset the protocol if an error occurs.
+           This can be removed when chrysn/aiocoap#79 is closed."""
         # Be responsible and clean up.
         yield from protocol.shutdown()
         nonlocal _protocol
         _protocol = None
         # Let any observers know the protocol has been shutdown.
-        nonlocal _observations_err_callbacks
         for ob_error in _observations_err_callbacks:
             ob_error(exc)
         _observations_err_callbacks.clear()

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -3,7 +3,6 @@ import asyncio
 import json
 import logging
 
-import aiocoap
 from aiocoap import Message, Context
 from aiocoap.error import RequestTimedOut, Error, ConstructionRenderableError
 from aiocoap.numbers.codes import Code
@@ -66,7 +65,7 @@ def api_factory(host, security_code, loop=None):
         nonlocal _observations_err_callbacks
         for ob_error in _observations_err_callbacks:
             ob_error(exc)
-        _observations.clear()
+        _observations_err_callbacks.clear()
 
     @asyncio.coroutine
     def _get_response(msg):

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -62,6 +62,7 @@ def api_factory(host, security_code, loop=None):
         nonlocal _protocol
         _protocol = None
         # Let any observers know the protocol has been shutdown.
+        nonlocal _observations_err_callbacks
         for ob_error in _observations_err_callbacks:
             ob_error(exc)
         _observations_err_callbacks.clear()

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -61,7 +61,7 @@ def api_factory(host, security_code, loop=None):
         nonlocal _protocol
         protocol = yield from _get_protocol()
         # Let any observers know the protocol has been shutdown.
-        yield from _get_protocol().shutdown()
+        yield from protocol.shutdown()
         _protocol = None
 
     @asyncio.coroutine

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -229,9 +229,10 @@ class Light:
     def __repr__(self):
         state = "on" if self.state else "off"
         return "<Light #{} - " \
+               "name: {}, " \
                "state: {}, " \
                "dimmer: {}, "\
                "hex_color: {}, " \
                "xy_color: {}" \
-               ">".format(self.index, state, self.dimmer, self.hex_color,
-                          self.xy_color)
+               ">".format(self.index, self.device.name, state, self.dimmer,
+                          self.hex_color, self.xy_color)


### PR DESCRIPTION
Feedback welcome, if there's a better way of handling this please let me know.

The reasons for this;

- If a new protocol is created for every request, a maximum of 3 observations can be obtained, this may be due to sockets or limitations elsewhere.
- In my testing, if a protocol is created and the Gateway is turned off, then turned on again, no further requests appear to be successful