### PR TITLE
Support for utf8 in lights names

### DIFF
--- a/pytradfri/api/libcoap_api.py
+++ b/pytradfri/api/libcoap_api.py
@@ -48,7 +48,6 @@ def api_factory(host, security_code):
         kwargs = {
             'stderr': subprocess.DEVNULL,
             'timeout': timeout,
-            'universal_newlines': True,
         }
 
         if data is not None:
@@ -62,7 +61,7 @@ def api_factory(host, security_code):
         command.append(url)
 
         try:
-            return_value = subprocess.check_output(command, **kwargs)
+            return_value = subprocess.check_output(command, **kwargs).decode('utf-8')
         except subprocess.TimeoutExpired:
             raise RequestTimeout() from None
         except subprocess.CalledProcessError as err:


### PR DESCRIPTION
There may exist more python-ish way to do it. I'm using provided dockerized environment and encountered problem with running this tool when my lights had non-ASCII characters in names..