### PR TITLE
Set global UTF-8 locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ COPY ./script/install-aiocoap.sh install-aiocoap.sh
 RUN ./install-aiocoap.sh
 
 WORKDIR /usr/src/app
+ENV LANG=C.UTF-8
 CMD /bin/bash


### PR DESCRIPTION
Without it it's not possible to use pytradfri API in `./script/dev_docker` when bulbs have utf-8 chars in names.