### PR TITLE
Fix git URL in aiocoap.sh

### DIFF
--- a/script/install-aiocoap.sh
+++ b/script/install-aiocoap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-git clone --depth 1 https://git.fslab.de/jkonra2m/tinydtls
+git clone --depth 1 https://git.fslab.de/jkonra2m/tinydtls.git
 cd tinydtls
 autoreconf
 ./configure --with-ecc --without-debug


### PR DESCRIPTION
This patch fixes the tinydtls gitlab link (it was missing the .git suffix).