### PR TITLE
Add sRGB to xyY conversion

### DIFF
--- a/pytradfri/color.py
+++ b/pytradfri/color.py
@@ -10,6 +10,34 @@ MAX_KELVIN = 25000
 MIN_KELVIN_WS = 2200
 MAX_KELVIN_WS = 4000
 
+# Extracted from Tradfri Android App string.xml
+COLOR_NAMES = {
+    '4a418a': 'Blue',
+    '6c83ba': 'Light Blue',
+    '8f2686': 'Saturated Purple',
+    'a9d62b': 'Lime',
+    'c984bb': 'Light Purple',
+    'd6e44b': 'Yellow',
+    'd9337c': 'Saturated Pink',
+    'da5d41': 'Dark Peach',
+    'dc4b31': 'Saturated Red',
+    'dcf0f8': 'Cold sky',
+    'e491af': 'Pink',
+    'e57345': 'Peach',
+    'e78834': 'Warm Amber',
+    'e8bedd': 'Light Pink',
+    'eaf6fb': 'Cool daylight',
+    'ebb63e': 'Candlelight',
+    'efd275': 'Warm glow',
+    'f1e0b5': 'Warm white',
+    'f2eccf': 'Sunrise',
+    'f5faf6': 'Cool white'
+}
+# When setting colors by name via the API,
+# lowercase strings with no spaces are preferred
+COLORS = {name.lower().replace(" ", "_"): hex
+          for hex, name in COLOR_NAMES.items()}
+
 
 def can_kelvin_to_xy(k):
     return MIN_KELVIN <= k <= MAX_KELVIN

--- a/pytradfri/color.py
+++ b/pytradfri/color.py
@@ -1,4 +1,3 @@
-import math
 from .const import (ATTR_LIGHT_COLOR_X as X, ATTR_LIGHT_COLOR_Y as Y)
 
 
@@ -55,17 +54,21 @@ def xy2tradfri(x, y):
 
 
 def kelvin_to_xyY(T):
-    # Sources: "Design of Advanced Color - Temperature Control System for HDTV Applications" [Lee, Cho, Kim]
+    # Sources: "Design of Advanced Color - Temperature Control System
+    #           for HDTV Applications" [Lee, Cho, Kim]
     # and https://en.wikipedia.org/wiki/Planckian_locus#Approximation
     # and http://fcam.garage.maemo.org/apiDocs/_color_8cpp_source.html
     if not (1667 <= T <= 25000):
         return None, None
 
     if T <= 4000:
-        # One number differs on Wikipedia and the paper: 0.2343589 is 0.2343580 on Wikipedia... don't know why
-        x = -0.2661239*(10**9)/T**3 - 0.2343589*(10**6)/T**2 + 0.8776956*(10**3)/T + 0.17991
+        # One number differs on Wikipedia and the paper:
+        #     0.2343589 is 0.2343580 on Wikipedia... don't know why
+        x = -0.2661239*(10**9)/T**3 - 0.2343589*(10**6)/T**2 \
+            + 0.8776956*(10**3)/T + 0.17991
     elif T <= 25000:
-        x = -3.0258469*(10**9)/T**3 + 2.1070379*(10**6)/T**2 + 0.2226347*(10**3)/T + 0.24039
+        x = -3.0258469*(10**9)/T**3 + 2.1070379*(10**6)/T**2 \
+            + 0.2226347*(10**3)/T + 0.24039
 
     if T <= 2222:
         y = -1.1063814*x**3 - 1.3481102*x**2 + 2.18555832*x - 0.20219683
@@ -75,21 +78,26 @@ def kelvin_to_xyY(T):
         y = 3.081758*x**3 - 5.8733867*x**2 + 3.75112997*x - 0.37001483
 
     x, y = xy2tradfri(x, y)
-    return { X: x, Y: y }
+    return {X: x, Y: y}
 
 
 def rgb_to_xyY(r, g, b):
     # According to http://www.brucelindbloom.com/index.html?Eqn_RGB_to_XYZ.html
     # and http://www.brucelindbloom.com/index.html?Eqn_XYZ_to_xyY.html
-    companding = lambda x: x / 12.92 if x <= 0.04045 else ((x + 0.055) / 1.055) ** 2.4
-    prepare = lambda x: companding(max(min(x,255),0) / 255.0)
+    def prepare(val):
+        val = max(min(val, 255), 0) / 255.0
+        if val <= 0.04045:
+            return val / 12.92
+        else:
+            return ((val + 0.055) / 1.055) ** 2.4
     r, g, b = map(prepare, (r, g, b))
 
-    # sRGB D65 matrix from http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+    # source: http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
     CIE_X = 0.4124564*r + 0.3575761*g + 0.1804375*b
     CIE_Y = 0.2126729*r + 0.7151522*g + 0.0721750*b
     CIE_Z = 0.0193339*r + 0.1191920*g + 0.9503041*b
     CIE_sum = CIE_X + CIE_Y + CIE_Z
 
-    (x, y) = (0, 0) if CIE_sum == 0 else xy2tradfri(CIE_X / CIE_sum, CIE_Y / CIE_sum)
-    return { X: x, Y: y }
+    (x, y) = (0, 0) if CIE_sum == 0 else \
+        xy2tradfri(CIE_X / CIE_sum, CIE_Y / CIE_sum)
+    return {X: x, Y: y}

--- a/pytradfri/color.py
+++ b/pytradfri/color.py
@@ -49,6 +49,29 @@ def x_to_kelvin(x):
     return int(offset * higher + (1 - offset) * lower)
 
 
+def kelvin_to_xyY(T):
+    # Sources: "Design of Advanced Color - Temperature Control System for HDTV Applications" [Lee, Cho, Kim]
+    # and https://en.wikipedia.org/wiki/Planckian_locus#Approximation
+    # and http://fcam.garage.maemo.org/apiDocs/_color_8cpp_source.html
+    if not (1667 <= T <= 25000):
+        return None, None
+
+    if T <= 4000:
+        # One number differs on Wikipedia and the paper: 0.2343589 is 0.2343580 on Wikipedia... don't know why
+        x = -0.2661239*(10**9)/T**3 - 0.2343589*(10**6)/T**2 + 0.8776956*(10**3)/T + 0.17991
+    elif T <= 25000:
+        x = -3.0258469*(10**9)/T**3 + 2.1070379*(10**6)/T**2 + 0.2226347*(10**3)/T + 0.24039
+
+    if T <= 2222:
+        y = -1.1063814*x**3 - 1.3481102*x**2 + 2.18555832*x - 0.20219683
+    elif T <= 4000:
+        y = -0.9549476*x**3 - 1.37418593*x**2 + 2.09137015*x - 0.16748867
+    elif T <= 25000:
+        y = 3.081758*x**3 - 5.8733867*x**2 + 3.75112997*x - 0.37001483
+
+    return int(x*65535+0.5), int(y*65535+0.5)
+
+
 def rgb_to_xyY(r, g, b):
     # According to http://www.brucelindbloom.com/index.html?Eqn_RGB_to_XYZ.html
     # and http://www.brucelindbloom.com/index.html?Eqn_XYZ_to_xyY.html

--- a/pytradfri/color.py
+++ b/pytradfri/color.py
@@ -1,8 +1,14 @@
 from .const import (ATTR_LIGHT_COLOR_X as X, ATTR_LIGHT_COLOR_Y as Y)
 
 
+# Kelvin range for which the conversion functions work
+# and that RGB bulbs can show
 MIN_KELVIN = 1667
 MAX_KELVIN = 25000
+
+# Kelvin range that white-spectrum bulbs can actually show
+MIN_KELVIN_WS = 2200
+MAX_KELVIN_WS = 4000
 
 
 def can_kelvin_to_xy(k):
@@ -14,13 +20,22 @@ def xy2tradfri(x, y):
     return (int(x*65535+0.5), int(y*65535+0.5))
 
 
-def kelvin_to_xyY(T):
+def kelvin_to_xyY(T, white_spectrum_bulb=False):
     # Sources: "Design of Advanced Color - Temperature Control System
     #           for HDTV Applications" [Lee, Cho, Kim]
     # and https://en.wikipedia.org/wiki/Planckian_locus#Approximation
     # and http://fcam.garage.maemo.org/apiDocs/_color_8cpp_source.html
-    if not (1667 <= T <= 25000):
-        return None
+
+    # Check for Kelvin range for which this function works
+    if not (MIN_KELVIN <= T <= MAX_KELVIN):
+        raise ValueError('Kelvin needs to be between {} and {}'.format(
+            MIN_KELVIN, MAX_KELVIN))
+
+    # Check for White-Spectrum kelvin range
+    if white_spectrum_bulb and not (MIN_KELVIN_WS <= T <= MAX_KELVIN_WS):
+        raise ValueError('Kelvin needs to be between {} and {} for '
+                         'white spectrum bulbs'.format(
+                          MIN_KELVIN_WS, MAX_KELVIN_WS))
 
     if T <= 4000:
         # One number differs on Wikipedia and the paper:

--- a/pytradfri/color.py
+++ b/pytradfri/color.py
@@ -92,7 +92,7 @@ def xyY_to_kelvin(x, y):
     # Input range for x and y is 0-65535
     n = (x/65535-0.3320) / (y/65535-0.1858)
     kelvin = int((-449*n**3 + 3525*n**2 - 6823.3*n + 5520.33) + 0.5)
-    return kelvin if MIN_KELVIN <= kelvin <= MAX_KELVIN else None
+    return kelvin
 
 
 def rgb2xyzA(r, g, b):

--- a/pytradfri/color.py
+++ b/pytradfri/color.py
@@ -1,3 +1,4 @@
+import math
 from .const import (ATTR_LIGHT_COLOR_X as X, ATTR_LIGHT_COLOR_Y as Y)
 
 
@@ -46,3 +47,21 @@ def x_to_kelvin(x):
     higher = x_to_kelvin(higher_x)
     offset = (x - lower_x) / (higher_x - lower_x)
     return int(offset * higher + (1 - offset) * lower)
+
+
+def rgb_to_xyY(r, g, b):
+    # According to http://www.brucelindbloom.com/index.html?Eqn_RGB_to_XYZ.html
+    # and http://www.brucelindbloom.com/index.html?Eqn_XYZ_to_xyY.html
+    companding = lambda x: x / 12.92 if x <= 0.04045 else ((x + 0.055) / 1.055) ** 2.4
+    prepare = lambda x: companding(max(min(x,255),0) / 255.0)
+    r, g, b = map(prepare, (r, g, b))
+
+    # sRGB D65 matrix from http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+    CIE_X = 0.4124564*r + 0.3575761*g + 0.1804375*b
+    CIE_Y = 0.2126729*r + 0.7151522*g + 0.0721750*b
+    CIE_Z = 0.0193339*r + 0.1191920*g + 0.9503041*b
+    CIE_sum = CIE_X + CIE_Y + CIE_Z
+
+    (x, y) = (0, 0) if CIE_sum == 0 else (CIE_X / CIE_sum * 65535, CIE_Y / CIE_sum * 65535)
+
+    return { X: x, Y: y }

--- a/pytradfri/color.py
+++ b/pytradfri/color.py
@@ -49,6 +49,11 @@ def x_to_kelvin(x):
     return int(offset * higher + (1 - offset) * lower)
 
 
+# Scaling to 65535 range and rounding
+def xy2tradfri(x, y):
+    return (int(x*65535+0.5), int(y*65535+0.5))
+
+
 def kelvin_to_xyY(T):
     # Sources: "Design of Advanced Color - Temperature Control System for HDTV Applications" [Lee, Cho, Kim]
     # and https://en.wikipedia.org/wiki/Planckian_locus#Approximation
@@ -69,7 +74,8 @@ def kelvin_to_xyY(T):
     elif T <= 25000:
         y = 3.081758*x**3 - 5.8733867*x**2 + 3.75112997*x - 0.37001483
 
-    return int(x*65535+0.5), int(y*65535+0.5)
+    x, y = xy2tradfri(x, y)
+    return { X: x, Y: y }
 
 
 def rgb_to_xyY(r, g, b):
@@ -85,6 +91,5 @@ def rgb_to_xyY(r, g, b):
     CIE_Z = 0.0193339*r + 0.1191920*g + 0.9503041*b
     CIE_sum = CIE_X + CIE_Y + CIE_Z
 
-    (x, y) = (0, 0) if CIE_sum == 0 else (CIE_X / CIE_sum * 65535, CIE_Y / CIE_sum * 65535)
-
+    (x, y) = (0, 0) if CIE_sum == 0 else xy2tradfri(CIE_X / CIE_sum, CIE_Y / CIE_sum)
     return { X: x, Y: y }

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -16,7 +16,8 @@ from .const import (
     ATTR_LIGHT_COLOR,
     ATTR_TRANSITION_TIME
 )
-from .color import kelvin_to_xyY, xyY_to_kelvin, rgb_to_xyY, COLORS
+from .color import can_kelvin_to_xy, kelvin_to_xyY, xyY_to_kelvin, rgb_to_xyY,\
+    COLORS
 from .resource import ApiResource
 
 
@@ -241,7 +242,10 @@ class Light:
         current_x = self.raw.get(ATTR_LIGHT_COLOR_X)
         current_y = self.raw.get(ATTR_LIGHT_COLOR_Y)
         if current_x is not None and current_y is not None:
-            return xyY_to_kelvin(current_x, current_y)
+            kelvin = xyY_to_kelvin(current_x, current_y)
+            # Only return a kelvin value if it is inside the range that the
+            # kelvin->xyY function supports
+            return kelvin if can_kelvin_to_xy(kelvin) else None
 
     @property
     def raw(self):

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -16,7 +16,7 @@ from .const import (
     ATTR_LIGHT_COLOR,
     ATTR_TRANSITION_TIME
 )
-from .color import kelvin_to_xyY, xyY_to_kelvin, rgb_to_xyY
+from .color import kelvin_to_xyY, xyY_to_kelvin, rgb_to_xyY, COLORS
 from .resource import ApiResource
 
 
@@ -177,6 +177,14 @@ class LightControl:
 
     def set_kelvin_color(self, kelvins, *, index=0):
         return self.set_values(kelvin_to_xyY(kelvins), index=index)
+
+    def set_predefined_color(self, colorname, *, index=0):
+        try:
+            color = COLORS[colorname.lower().replace(" ", "_")]
+        except:
+            pass
+        else:
+            return self.set_hex_color(color, index=index)
 
     def set_rgb_color(self, r, g, b, *, index=0):
         return self.set_values(rgb_to_xyY(r, g, b), index=index)

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -16,7 +16,7 @@ from .const import (
     ATTR_LIGHT_COLOR,
     ATTR_TRANSITION_TIME
 )
-from .color import kelvin_to_xy, x_to_kelvin, can_x_to_kelvin
+from .color import kelvin_to_xy, x_to_kelvin, can_x_to_kelvin, rgb_to_xyY
 from .resource import ApiResource
 
 
@@ -177,6 +177,9 @@ class LightControl:
 
     def set_kelvin_color(self, kelvins, *, index=0):
         return self.set_values(kelvin_to_xy(kelvins), index=index)
+
+    def set_rgb_color(self, r, g, b, *, index=0):
+        return self.set_values(rgb_to_xyY(r, g, b), index=index)
 
     def set_values(self, values, *, index=0):
         """

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -16,7 +16,7 @@ from .const import (
     ATTR_LIGHT_COLOR,
     ATTR_TRANSITION_TIME
 )
-from .color import kelvin_to_xy, x_to_kelvin, can_x_to_kelvin, rgb_to_xyY
+from .color import kelvin_to_xyY, xyY_to_kelvin, rgb_to_xyY
 from .resource import ApiResource
 
 
@@ -176,7 +176,7 @@ class LightControl:
         }, index=index)
 
     def set_kelvin_color(self, kelvins, *, index=0):
-        return self.set_values(kelvin_to_xy(kelvins), index=index)
+        return self.set_values(kelvin_to_xyY(kelvins), index=index)
 
     def set_rgb_color(self, r, g, b, *, index=0):
         return self.set_values(rgb_to_xyY(r, g, b), index=index)
@@ -231,8 +231,9 @@ class Light:
     @property
     def kelvin_color(self):
         current_x = self.raw.get(ATTR_LIGHT_COLOR_X)
-        if current_x is not None and can_x_to_kelvin(current_x):
-            return x_to_kelvin(current_x)
+        current_y = self.raw.get(ATTR_LIGHT_COLOR_Y)
+        if current_x is not None and current_y is not None:
+            return xyY_to_kelvin(current_x, current_y)
 
     @property
     def raw(self):

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,34 +1,36 @@
+from pytradfri.const import (ATTR_LIGHT_COLOR_X as X, ATTR_LIGHT_COLOR_Y as Y)
 from pytradfri.color import kelvin_to_xy, x_to_kelvin, \
+    kelvin_to_xyY, rgb_to_xyY, \
     can_kelvin_to_xy, can_x_to_kelvin
 
 
 def test_known_warm():
-    assert kelvin_to_xy(2200) == {'5709': 33135, '5710': 27211}
+    assert kelvin_to_xy(2200) == {X: 33135, Y: 27211}
     assert x_to_kelvin(33135) == 2200
 
 
 def test_known_norm():
-    assert kelvin_to_xy(2700) == {'5709': 30140, '5710': 26909}
+    assert kelvin_to_xy(2700) == {X: 30140, Y: 26909}
     assert x_to_kelvin(30140) == 2700
 
 
 def test_known_cold():
-    assert kelvin_to_xy(4000) == {'5709': 24930, '5710': 24694}
+    assert kelvin_to_xy(4000) == {X: 24930, Y: 24694}
     assert x_to_kelvin(24930) == 4000
 
 
 def test_unknown_warmish():
     assert kelvin_to_xy((2200 + 2700) // 2) == {
-        '5709': (33135 + 30140) // 2,
-        '5710': (27211 + 26909) // 2
+        X: (33135 + 30140) // 2,
+        Y: (27211 + 26909) // 2
     }
     assert x_to_kelvin((33135 + 30140) // 2) == (2200 + 2700) // 2
 
 
 def test_unknown_coldish():
     assert kelvin_to_xy((2700 + 4000) // 2) == {
-        '5709': (30140 + 24930) // 2,
-        '5710': (26909 + 24694) // 2
+        X: (30140 + 24930) // 2,
+        Y: (26909 + 24694) // 2
     }
     assert x_to_kelvin((30140 + 24930) // 2) == (2700 + 4000) // 2
 
@@ -48,3 +50,37 @@ def test_can_dekelvinize():
     assert can_x_to_kelvin(32000) is True
     assert can_x_to_kelvin(33135) is True
     assert can_x_to_kelvin(34000) is False
+
+def test_kelvin_to_xyY():
+    # kelvin_to_xyY approximates, so +-50 is sufficiently precise.
+    # Values taken from Tradfri App, these only differ slightly from online
+    # calculators such as https://www.ledtuning.nl/en/cie-convertor
+
+    warm = kelvin_to_xyY(2200)
+    assert warm[X] in range(33135-50, 33135+51)
+    assert warm[Y] in range(27211-50, 27211+51)
+
+    normal = kelvin_to_xyY(2700)
+    assert normal[X] in range(30140-50, 30140+51)
+    assert normal[Y] in range(26909-50, 26909+51)
+
+    cold = kelvin_to_xyY(4000)
+    assert cold[X] in range(24930-50, 24930+51)
+    assert cold[Y] in range(24694-50, 24694+51)
+
+
+def test_rgb_to_xyY():
+    # rgb_to_xyY approximates, so +-50 is sufficiently precise.
+    # Verification values calculated by http://colormine.org/convert/rgb-to-xyz
+
+    red = rgb_to_xyY(255, 0, 0)
+    assert red[X] in range(41947-50, 41947+51)
+    assert red[Y] in range(21625-50, 21625+51)
+
+    green = rgb_to_xyY(0, 255, 0)
+    assert green[X] in range(19661-50, 19661+51)
+    assert green[Y] in range(39321-50, 39321+51)
+
+    blue = rgb_to_xyY(0, 0, 255)
+    assert blue[X] in range(9831-50, 9831+51)
+    assert blue[Y] in range(3933-50, 3933+51)

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,55 +1,20 @@
 from pytradfri.const import (ATTR_LIGHT_COLOR_X as X, ATTR_LIGHT_COLOR_Y as Y)
-from pytradfri.color import kelvin_to_xy, x_to_kelvin, \
-    kelvin_to_xyY, rgb_to_xyY, \
-    can_kelvin_to_xy, can_x_to_kelvin
-
-
-def test_known_warm():
-    assert kelvin_to_xy(2200) == {X: 33135, Y: 27211}
-    assert x_to_kelvin(33135) == 2200
-
-
-def test_known_norm():
-    assert kelvin_to_xy(2700) == {X: 30140, Y: 26909}
-    assert x_to_kelvin(30140) == 2700
-
-
-def test_known_cold():
-    assert kelvin_to_xy(4000) == {X: 24930, Y: 24694}
-    assert x_to_kelvin(24930) == 4000
-
-
-def test_unknown_warmish():
-    assert kelvin_to_xy((2200 + 2700) // 2) == {
-        X: (33135 + 30140) // 2,
-        Y: (27211 + 26909) // 2
-    }
-    assert x_to_kelvin((33135 + 30140) // 2) == (2200 + 2700) // 2
-
-
-def test_unknown_coldish():
-    assert kelvin_to_xy((2700 + 4000) // 2) == {
-        X: (30140 + 24930) // 2,
-        Y: (26909 + 24694) // 2
-    }
-    assert x_to_kelvin((30140 + 24930) // 2) == (2700 + 4000) // 2
+from pytradfri.color import can_kelvin_to_xy, kelvin_to_xyY, xyY_to_kelvin, \
+    rgb_to_xyY
 
 
 def test_can_dekelvinize():
-    assert can_kelvin_to_xy(2000) is False
+    assert can_kelvin_to_xy(1600) is False
+    assert can_kelvin_to_xy(1800) is True
+    assert can_kelvin_to_xy(2000) is True
     assert can_kelvin_to_xy(2200) is True
     assert can_kelvin_to_xy(2400) is True
     assert can_kelvin_to_xy(2700) is True
     assert can_kelvin_to_xy(3000) is True
     assert can_kelvin_to_xy(4000) is True
-    assert can_kelvin_to_xy(5000) is False
-    assert can_x_to_kelvin(24000) is False
-    assert can_x_to_kelvin(24930) is True
-    assert can_x_to_kelvin(26000) is True
-    assert can_x_to_kelvin(30140) is True
-    assert can_x_to_kelvin(32000) is True
-    assert can_x_to_kelvin(33135) is True
-    assert can_x_to_kelvin(34000) is False
+    assert can_kelvin_to_xy(5000) is True
+    assert can_kelvin_to_xy(25000) is True
+    assert can_kelvin_to_xy(26000) is False
 
 
 def test_kelvin_to_xyY():
@@ -68,6 +33,19 @@ def test_kelvin_to_xyY():
     cold = kelvin_to_xyY(4000)
     assert cold[X] in range(24930-50, 24930+51)
     assert cold[Y] in range(24694-50, 24694+51)
+
+
+def test_xyY_to_kelvin():
+    # xyY_to_kelvin approximates, so +-20 is sufficiently precise.
+    # Values taken from Tradfri App.
+    warm = xyY_to_kelvin(33135, 27211)
+    assert warm in range(2200-20, 2200+21)
+
+    normal = xyY_to_kelvin(30140, 26909)
+    assert normal in range(2700-20, 2700+21)
+
+    cold = xyY_to_kelvin(24930, 24694)
+    assert cold in range(4000-20, 4000+21)
 
 
 def test_rgb_to_xyY():

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -51,6 +51,7 @@ def test_can_dekelvinize():
     assert can_x_to_kelvin(33135) is True
     assert can_x_to_kelvin(34000) is False
 
+
 def test_kelvin_to_xyY():
     # kelvin_to_xyY approximates, so +-50 is sufficiently precise.
     # Values taken from Tradfri App, these only differ slightly from online


### PR DESCRIPTION
This is the foundation needed for #50.
I tested the function with some values and it works great when looking at this image: https://upload.wikimedia.org/wikipedia/commons/3/3b/CIE1931xy_blank.svg
The function uses the sRGB function with D65 white, also I wanted to keep this function minimalistic.
@matemaciek's PR is the base for this, as the RGB color stuff should be integrated in color.py, I think. 

When more sophisticated conversion functions may be needed in the future, https://github.com/gtaylor/python-colormath might be worth a try.
The inverse function to calculate RGB from given xyY would also maybe be useful.