### PR TITLE
Update device.py

### DIFF
--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -48,7 +48,8 @@ class Device(ApiResource):
 
     @property
     def has_light_control(self):
-        return (self.raw is not None and len(self.raw.get(ATTR_LIGHT_CONTROL,"")) > 0)
+        return (self.raw is not None and 
+                len(self.raw.get(ATTR_LIGHT_CONTROL,"")) > 0)
 
     @property
     def light_control(self):

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -48,7 +48,7 @@ class Device(ApiResource):
 
     @property
     def has_light_control(self):
-        return (self.raw is not None and 
+        return (self.raw is not None and
                 len(self.raw.get(ATTR_LIGHT_CONTROL, "")) > 0)
 
     @property

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -49,7 +49,7 @@ class Device(ApiResource):
     @property
     def has_light_control(self):
         return (self.raw is not None and 
-                len(self.raw.get(ATTR_LIGHT_CONTROL,"")) > 0)
+                len(self.raw.get(ATTR_LIGHT_CONTROL, "")) > 0)
 
     @property
     def light_control(self):

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -48,8 +48,7 @@ class Device(ApiResource):
 
     @property
     def has_light_control(self):
-        return (ATTR_LIGHT_CONTROL in self.raw and
-                len(self.raw.get(ATTR_LIGHT_CONTROL)) > 0)
+        return (self.raw is not None and len(self.raw.get(ATTR_LIGHT_CONTROL,"")) > 0)
 
     @property
     def light_control(self):


### PR DESCRIPTION
If the device is an input instead of a lamp then self.raw is None and has_light_control should return False.
This change caters for that scenario.