### PR TITLE
Fixing device.py so that Travis doesn't fail, added test and support for coverall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ language: python
 script:
   - py.test
   - flake8
+after_success:
+  - coveralls

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -217,7 +217,7 @@ class LightControl:
         try:
             color = COLORS[colorname.lower().replace(" ", "_")]
         except:
-            pass
+            raise PyTradFriError('Could not match color name')
         else:
             return self.set_hex_color(color, index=index)
 

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -20,6 +20,7 @@ from .color import can_kelvin_to_xy, kelvin_to_xyY, xyY_to_kelvin, rgb_to_xyY,\
     xy_brightness_to_rgb, COLORS, MIN_KELVIN, MAX_KELVIN,\
     MIN_KELVIN_WS, MAX_KELVIN_WS
 from .resource import ApiResource
+from .error import PyTradFriError
 
 
 class Device(ApiResource):

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -20,7 +20,6 @@ from .color import can_kelvin_to_xy, kelvin_to_xyY, xyY_to_kelvin, rgb_to_xyY,\
     xy_brightness_to_rgb, COLORS, MIN_KELVIN, MAX_KELVIN,\
     MIN_KELVIN_WS, MAX_KELVIN_WS
 from .resource import ApiResource
-from .error import PyTradFriError
 
 
 class Device(ApiResource):
@@ -218,7 +217,8 @@ class LightControl:
         try:
             color = COLORS[colorname.lower().replace(" ", "_")]
         except:
-            raise PyTradFriError('Could not match color name')
+            """If color name can't be matched, default to something"""
+            color = COLORS['sunrise']
         else:
             return self.set_hex_color(color, index=index)
 

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -20,6 +20,9 @@ from .color import can_kelvin_to_xy, kelvin_to_xyY, xyY_to_kelvin, rgb_to_xyY,\
     xy_brightness_to_rgb, COLORS, MIN_KELVIN, MAX_KELVIN,\
     MIN_KELVIN_WS, MAX_KELVIN_WS
 from .resource import ApiResource
+import logging
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Device(ApiResource):
@@ -217,8 +220,7 @@ class LightControl:
         try:
             color = COLORS[colorname.lower().replace(" ", "_")]
         except KeyError:
-            """If color name can't be matched, default to something"""
-            color = COLORS['sunrise']
+            _LOGGER.debug('Could not match color name')
 
         return self.set_hex_color(color, index=index)
 

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -216,7 +216,7 @@ class LightControl:
     def set_predefined_color(self, colorname, *, index=0):
         try:
             color = COLORS[colorname.lower().replace(" ", "_")]
-        except:
+        except KeyError:
             """If color name can't be matched, default to something"""
             color = COLORS['sunrise']
         else:

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -219,10 +219,9 @@ class LightControl:
     def set_predefined_color(self, colorname, *, index=0):
         try:
             color = COLORS[colorname.lower().replace(" ", "_")]
+            return self.set_hex_color(color, index=index)
         except KeyError:
             _LOGGER.debug('Could not match color name')
-        else:
-            return self.set_hex_color(color, index=index)
 
     def set_rgb_color(self, r, g, b, *, index=0):
         return self.set_values(rgb_to_xyY(r, g, b), index=index)

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -221,8 +221,8 @@ class LightControl:
             color = COLORS[colorname.lower().replace(" ", "_")]
         except KeyError:
             _LOGGER.debug('Could not match color name')
-
-        return self.set_hex_color(color, index=index)
+        else:
+            return self.set_hex_color(color, index=index)
 
     def set_rgb_color(self, r, g, b, *, index=0):
         return self.set_values(rgb_to_xyY(r, g, b), index=index)

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -219,8 +219,8 @@ class LightControl:
         except KeyError:
             """If color name can't be matched, default to something"""
             color = COLORS['sunrise']
-        else:
-            return self.set_hex_color(color, index=index)
+
+        return self.set_hex_color(color, index=index)
 
     def set_rgb_color(self, r, g, b, *, index=0):
         return self.set_values(rgb_to_xyY(r, g, b), index=index)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -60,6 +60,7 @@ def test_set_name():
     assert command.path == dev.path
     assert command.data == {ATTR_NAME: 'New name'}
 
+
 def test_setters():
     dev = Device(LIGHT)
     command = dev.set_predefined_color('Warm white')

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -59,3 +59,9 @@ def test_set_name():
     assert command.method == 'put'
     assert command.path == dev.path
     assert command.data == {ATTR_NAME: 'New name'}
+
+def test_setters():
+    dev = Device(LIGHT)
+    command = dev.set_predefined_color('Warm white')
+
+    assert command.hex_color == 'f1e0b5'

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -59,10 +59,3 @@ def test_set_name():
     assert command.method == 'put'
     assert command.path == dev.path
     assert command.data == {ATTR_NAME: 'New name'}
-
-
-def test_setters():
-    dev = Device(LIGHT)
-    command = dev.set_predefined_color('Warm white')
-
-    assert command.hex_color == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -237,4 +237,4 @@ def test_setters():
 
     cmd = Device(LIGHT_CWS).light_control \
         .set_predefined_color('Ggravlingen')
-    assert hasattr(cmd, data) == False
+    assert hasattr(cmd, 'data') is False

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -233,11 +233,12 @@ def test_color_device_control():
 
 def test_setters_v2():
     gateway = Gateway()
+    cmd = Device(gateway, LIGHT_CWS)
 
-    cmd = Device(gateway, LIGHT_CWS).light_control.lights[0]. \
-        set_predefined_color('Warm white')
+#    cmd.light_control.lights[0]. \
+#        set_predefined_color('Warm white')
 
-    assert cmd.data == {'9042': {'15013': [
-        {'5712': 18000, '5851': 30, '9003': 65537},
-        {'5712': 18000, '5851': 254, '9003': 65538}],
-        '5850': 1}}
+#    assert cmd.data == {'9042': {'15013': [
+#        {'5712': 18000, '5851': 30, '9003': 65537},
+#        {'5712': 18000, '5851': 254, '9003': 65538}],
+#        '5850': 1}}

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -235,3 +235,8 @@ def test_setters():
         .set_predefined_color('Warm glow')
 
     assert cmd.data == {'3311': [{'5706': 'efd275'}]}
+
+    cmd = Device(LIGHT_CWS).light_control \
+        .set_predefined_color('Ggravlingen')
+
+    assert cmd.data == {'3311': [{'5706': 'f2eccf'}]}

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -232,8 +232,8 @@ def test_color_device_control():
 
 
 def test_setters_v2():
-    cmd = Device(LIGHT_CWS).light_control.lights[0]. \
-        set_predefined_color('Warm white')
+    cmd = Device(LIGHT_CWS).light_control \
+        .set_predefined_color('Warm white')
 
     assert cmd.data == {'9042': {'15013': [
         {'5712': 18000, '5851': 30, '9003': 65537},

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -232,3 +232,5 @@ def test_color_device_control():
 def test_setters():
     light_control = light_device_control(LIGHT_CWS)
     light_control.set_predefined_color('Warm white')
+
+    assert light_control.light.hex_color == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -233,4 +233,4 @@ def test_setters():
     light_control = light_device_control(LIGHT_CWS)
     light_control.set_predefined_color('Warm white')
 
-    assert light_control.light.hex_color == 'f1e0b5'
+    assert light_control.lights.hex_color == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -230,7 +230,7 @@ def test_color_device_control():
     assert light_control.max_kelvin == 25000
 
 
-def test_setters_v2():
+def test_setters():
     cmd = Device(LIGHT_CWS).light_control \
         .set_predefined_color('Warm glow')
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -232,13 +232,10 @@ def test_color_device_control():
 
 
 def test_setters_v2():
-    gateway = Gateway()
-    cmd = Device(gateway, LIGHT_CWS)
+    cmd = Device(LIGHT_CWS).light_control.lights[0]. \
+        set_predefined_color('Warm white')
 
-#    cmd.light_control.lights[0]. \
-#        set_predefined_color('Warm white')
-
-#    assert cmd.data == {'9042': {'15013': [
-#        {'5712': 18000, '5851': 30, '9003': 65537},
-#        {'5712': 18000, '5851': 254, '9003': 65538}],
-#        '5850': 1}}
+    assert cmd.data == {'9042': {'15013': [
+        {'5712': 18000, '5851': 30, '9003': 65537},
+        {'5712': 18000, '5851': 254, '9003': 65538}],
+        '5850': 1}}

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -231,5 +231,4 @@ def test_color_device_control():
 
 def test_setters():
     light_control = light_device_control(LIGHT_CWS)
-    print(light_control.set_predefined_color('Warm white'))
-    assert light_control.set_predefined_color('Warm white') == 'f1e0b5'
+    light_control.set_predefined_color('Warm white')

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -232,5 +232,5 @@ def test_color_device_control():
 def test_setters():
     light_control = light_device_control(LIGHT_CWS)
     light_control.set_predefined_color('Warm white')
-
+    _LOGGER.debug('Executing %s %s %s: %s', host, method, path, data)
     assert light_control.lights[0].hex_color == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -237,5 +237,4 @@ def test_color_device_control():
 def test_setters():
     light_control = light_device_control(LIGHT_CWS)
     light_control.set_predefined_color('Warm white')
-    _LOGGER.debug('Testing %s ', light_control.lights[0].raw)
     assert light_control.lights[0].hex_color == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -233,10 +233,8 @@ def test_color_device_control():
 def test_setters():
     cmd = Device(LIGHT_CWS).light_control \
         .set_predefined_color('Warm glow')
-
     assert cmd.data == {'3311': [{'5706': 'efd275'}]}
 
     cmd = Device(LIGHT_CWS).light_control \
         .set_predefined_color('Ggravlingen')
-
     assert cmd.data == {'3311': [{'5706': 'f2eccf'}]}

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -227,3 +227,10 @@ def test_color_device_control():
     assert light_control.can_set_kelvin
     assert light_control.min_kelvin == 1667
     assert light_control.max_kelvin == 25000
+
+
+def test_setters():
+    light_control = light_device_control(LIGHT_CWS)
+    command = light_control.set_predefined_color('Warm white')
+
+    assert command.hex_color == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -237,4 +237,4 @@ def test_setters():
 
     cmd = Device(LIGHT_CWS).light_control \
         .set_predefined_color('Ggravlingen')
-    assert cmd.data == {'3311': [{'5706': 'f2eccf'}]}
+    assert cmd.data == None

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -237,4 +237,4 @@ def test_setters():
 
     cmd = Device(LIGHT_CWS).light_control \
         .set_predefined_color('Ggravlingen')
-    assert cmd.data is None
+    assert hasattr(cmd, data) == False

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -233,4 +233,4 @@ def test_setters():
     light_control = light_device_control(LIGHT_CWS)
     light_control.set_predefined_color('Warm white')
 
-    assert light_control.lights.hex_color == 'f1e0b5'
+    assert light_control.lights[0].hex_color == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -233,4 +233,4 @@ def test_setters():
     light_control = light_device_control(LIGHT_CWS)
     command = light_control.set_predefined_color('Warm white')
 
-    assert command.hex_color == 'f1e0b5'
+    assert command == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -231,6 +231,5 @@ def test_color_device_control():
 
 def test_setters():
     light_control = light_device_control(LIGHT_CWS)
-    command = light_control.set_predefined_color('Warm white')
-
-    assert command == 'f1e0b5'
+    print(light_control.set_predefined_color('Warm white'))
+    assert light_control.set_predefined_color('Warm white') == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,5 +1,10 @@
 from pytradfri.device import Device
 
+#  Remove later on
+import logging
+_LOGGER = logging.getLogger(__name__)
+
+
 LIGHT_W = {
     '3': {
         '0': 'IKEA of Sweden',

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -237,4 +237,4 @@ def test_setters():
 
     cmd = Device(LIGHT_CWS).light_control \
         .set_predefined_color('Ggravlingen')
-    assert cmd.data == None
+    assert cmd.data is None

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,8 +1,5 @@
 from pytradfri.device import Device
-
-#  Remove later on
-import logging
-_LOGGER = logging.getLogger(__name__)
+from pytradfri.gateway import Gateway
 
 
 LIGHT_W = {
@@ -234,7 +231,13 @@ def test_color_device_control():
     assert light_control.max_kelvin == 25000
 
 
-def test_setters():
-    light_control = light_device_control(LIGHT_CWS)
-    light_control.set_predefined_color('Warm white')
-    assert light_control.lights[0].hex_color == 'f1e0b5'
+def test_setters_v2():
+    gateway = Gateway()
+
+    cmd = Device(gateway, LIGHT_CWS).light_control.lights[0]. \
+        set_predefined_color('Warm white')
+
+    assert cmd.data == {'9042': {'15013': [
+        {'5712': 18000, '5851': 30, '9003': 65537},
+        {'5712': 18000, '5851': 254, '9003': 65538}],
+        '5850': 1}}

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -237,5 +237,5 @@ def test_color_device_control():
 def test_setters():
     light_control = light_device_control(LIGHT_CWS)
     light_control.set_predefined_color('Warm white')
-    _LOGGER.debug('Executing %s %s %s: %s', host, method, path, data)
+    _LOGGER.debug('Testing %s ', light_control.lights[0].raw)
     assert light_control.lights[0].hex_color == 'f1e0b5'

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,5 +1,4 @@
 from pytradfri.device import Device
-from pytradfri.gateway import Gateway
 
 
 LIGHT_W = {
@@ -233,9 +232,6 @@ def test_color_device_control():
 
 def test_setters_v2():
     cmd = Device(LIGHT_CWS).light_control \
-        .set_predefined_color('Warm white')
+        .set_predefined_color('Warm glow')
 
-    assert cmd.data == {'9042': {'15013': [
-        {'5712': 18000, '5851': 30, '9003': 65537},
-        {'5712': 18000, '5851': 254, '9003': 65538}],
-        '5850': 1}}
+    assert cmd.data == {'3311': [{'5706': 'efd275'}]}


### PR DESCRIPTION
In the current prod version of the code, Travis throws an error in device.py (#76). Oddly, the error wasn't there when the affected lines of code was first merged. This is a fix for that error so that Travis can build again.

I've also added a test for the set_predefined_color-method and support for coverall.