### PR TITLE
Fixing device.py so that Travis doesn't fail and added test

### DIFF
--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -20,6 +20,9 @@ from .color import can_kelvin_to_xy, kelvin_to_xyY, xyY_to_kelvin, rgb_to_xyY,\
     xy_brightness_to_rgb, COLORS, MIN_KELVIN, MAX_KELVIN,\
     MIN_KELVIN_WS, MAX_KELVIN_WS
 from .resource import ApiResource
+import logging
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Device(ApiResource):
@@ -216,10 +219,9 @@ class LightControl:
     def set_predefined_color(self, colorname, *, index=0):
         try:
             color = COLORS[colorname.lower().replace(" ", "_")]
-        except:
-            pass
-        else:
             return self.set_hex_color(color, index=index)
+        except KeyError:
+            _LOGGER.debug('Could not match color name')
 
     def set_rgb_color(self, r, g, b, *, index=0):
         return self.set_values(rgb_to_xyY(r, g, b), index=index)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "3.0.3"
+VERSION = "3.0.4"
 DOWNLOAD_URL = \
     'https://github.com/ggravlingen/pytradfri/archive/{}.zip'.format(VERSION)
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -227,3 +227,12 @@ def test_color_device_control():
     assert light_control.can_set_kelvin
     assert light_control.min_kelvin == 1667
     assert light_control.max_kelvin == 25000
+
+def test_setters():
+    cmd = Device(LIGHT_CWS).light_control \
+        .set_predefined_color('Warm glow')
+    assert cmd.data == {'3311': [{'5706': 'efd275'}]}
+
+    cmd = Device(LIGHT_CWS).light_control \
+        .set_predefined_color('Ggravlingen')
+    assert hasattr(cmd, 'data') is False

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -228,6 +228,7 @@ def test_color_device_control():
     assert light_control.min_kelvin == 1667
     assert light_control.max_kelvin == 25000
 
+
 def test_setters():
     cmd = Device(LIGHT_CWS).light_control \
         .set_predefined_color('Warm glow')


### PR DESCRIPTION
In the current prod version of the code, Travis throws an error in device.py (#76). Oddly, the error wasn't there when the affected lines of code was first merged. This is a fix for that error so that Travis can build again. I've also added a test for the set_predefined_color-method.