### PR TITLE
cleanup on asyncio.CancelledError

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -99,6 +99,9 @@ class APIFactory:
         except Error as e:
             yield from self._reset_protocol(e)
             raise ServerError("There was an error with the request.", e)
+        except asyncio.CancelledError as e:
+            yield from self._reset_protocol(e)
+            raise e
 
     @asyncio.coroutine
     def _execute(self, api_command):


### PR DESCRIPTION
This allows us to put a request in an async_timeout for example.
(aiocoaps default timeout is 1+ minute, and it can spit out a lot of DTLS error in certain conditions)

See: https://github.com/ggravlingen/pytradfri/issues/110