### PR TITLE
Libcoap observer timeout fix

### DIFF
--- a/pytradfri/api/libcoap_api.py
+++ b/pytradfri/api/libcoap_api.py
@@ -104,7 +104,7 @@ class APIFactory:
         path = api_command.path
         duration = api_command.observe_duration
         if duration <= 0:
-            duration = 1
+            raise ValueError("Observation duration has to be greater than 0.")
         url = api_command.url(self._host)
         err_callback = api_command.err_callback
 

--- a/pytradfri/api/libcoap_api.py
+++ b/pytradfri/api/libcoap_api.py
@@ -109,7 +109,7 @@ class APIFactory:
         err_callback = api_command.err_callback
 
         command = (self._base_command('get')
-                   + ['-s', str(duration), '-B', str(duration) url])
+                   + ['-s', str(duration), '-B', str(duration), url])
 
         kwargs = {
             'stdout': subprocess.PIPE,

--- a/pytradfri/api/libcoap_api.py
+++ b/pytradfri/api/libcoap_api.py
@@ -103,6 +103,8 @@ class APIFactory:
         """Observe an endpoint."""
         path = api_command.path
         duration = api_command.observe_duration
+        if duration <= 0:
+            duration = 1
         url = api_command.url(self._host)
         err_callback = api_command.err_callback
 

--- a/pytradfri/api/libcoap_api.py
+++ b/pytradfri/api/libcoap_api.py
@@ -106,7 +106,8 @@ class APIFactory:
         url = api_command.url(self._host)
         err_callback = api_command.err_callback
 
-        command = self._base_command('get') + ['-s', str(duration), url]
+        command = (self._base_command('get')
+                   + ['-s', str(duration), '-B', str(duration) url])
 
         kwargs = {
             'stdout': subprocess.PIPE,


### PR DESCRIPTION
I believe it's a known bug (though I can't find the issue) that in sync mode the observer always stops after 90 seconds. It was thought this was a bug in Libcoap itself, but it turns out it's just a default. From `$ coap-client -h`:

```
	-B seconds	break operation after waiting given seconds
			(default is 90)
```

Adding the -B flag with the observation duration to the command fixes this bug. Though make sure `duration > 0` otherwise it goes haywire.