### PR TITLE
Re-add supported features.

### DIFF
--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -145,7 +145,7 @@ class LightControl:
 
     def __init__(self, device):
         self._device = device
-        
+
         self.can_set_temp = None
         self.can_set_color = None
 

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -145,6 +145,15 @@ class LightControl:
 
     def __init__(self, device):
         self._device = device
+        
+        self.can_set_temp = None
+        self.can_set_color = None
+
+        if 'WS' in self._device.device_info.model_number:
+            self.can_set_temp = True
+
+        if 'CWS' in self._device.device_info.model_number:
+            self.can_set_color = True
 
     @property
     def raw(self):

--- a/pytradfri/device.py
+++ b/pytradfri/device.py
@@ -155,6 +155,9 @@ class LightControl:
         if 'CWS' in self._device.device_info.model_number:
             self.can_set_color = True
 
+        self.min_mireds = RANGE_MIREDS[0]
+        self.max_mireds = RANGE_MIREDS[1]
+
     @property
     def raw(self):
         """Return raw data that it represents."""

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-VERSION = "5.4.0"
+VERSION = "5.4.1"
 DOWNLOAD_URL = \
     'https://github.com/ggravlingen/pytradfri/archive/{}.zip'.format(VERSION)
 


### PR DESCRIPTION
Not sure why this was removed with the range validation, but it's needed in order to know what features a bulb supports.