### PR TITLE
Omit main from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,3 +13,5 @@ exclude_lines =
     # Don't complain if tests don't hit defensive assertion code:
     raise AssertionError
     raise NotImplementedError
+omit =
+    pytradfri/__main__.py


### PR DESCRIPTION
I don't think it makes sense to include the CLI in the coverage stats as it isn't part of the library code, more like an example?