### PR TITLE
Catch OSError and socket.gaierror

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+import socket
 
 from aiocoap import Message, Context
 from aiocoap.error import RequestTimedOut, Error, ConstructionRenderableError
@@ -102,7 +103,9 @@ class APIFactory:
         except RequestTimedOut as e:
             yield from self._reset_protocol(e)
             raise RequestTimeout('Request timed out.', e)
-        except Error as e:
+        except (OSError, socket.gaierror, Error) as e:
+            # aiocoap sometimes raises an OSError/socket.gaierror too.
+            # aiocoap issue #124
             yield from self._reset_protocol(e)
             raise ServerError("There was an error with the request.", e)
         except asyncio.CancelledError as e:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-VERSION = "6.0.0"
+VERSION = "6.0.1"
 DOWNLOAD_URL = \
     'https://github.com/ggravlingen/pytradfri/archive/{}.zip'.format(VERSION)
 


### PR DESCRIPTION
Catch OSError and socket.gaierror when fetching a response with aiocoap.

Can be removed when upstream issue fixed: https://github.com/chrysn/aiocoap/issues/124