### PR TITLE
Fixing ImportError: No module named 'typing'

### DIFF
--- a/DockerfileRPI
+++ b/DockerfileRPI
@@ -12,4 +12,6 @@ WORKDIR /usr/src/app
 COPY ./script/install-coap-client.sh install-coap-client.sh
 RUN ./install-coap-client.sh
 
+RUN /usr/bin/pip3 install --upgrade typing
+
 CMD /bin/bash


### PR DESCRIPTION
Kept getting: ImportError: No module named 'typing'
/usr/bin/pip3 install --upgrade typing