### PR TITLE
Simplify chained comparisons

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -215,9 +215,9 @@ def _process_output(res, parse_json=True):
         return None
 
     if not res.code.is_successful:
-        if res.code >= 128 and res.code < 160:
+        if 128 <= res.code < 160:
             raise ClientError(output)
-        elif res.code >= 160 and res.code < 192:
+        elif 160 <= res.code < 192:
             raise ServerError(output)
 
     if not parse_json:


### PR DESCRIPTION
> ***Comparisons can be chained arbitrarily, e.g., x < y <= z is equivalent to x < y and y <= z, except that y is evaluated only once (but in both cases z is not evaluated at all when x < y is found to be false).***

* https://docs.python.org/3/reference/expressions.html#comparisons
