### PR TITLE
A bit more stable observations

### DIFF
--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -144,6 +144,11 @@ async def run():
     print("Try altering any light in the app, and watch the events!")
     await asyncio.sleep(120)
 
+    print('Force cancelling the controlling light as an example')
+    observe_cancel_command = light.observe_cancel()
+    asyncio.ensure_future(api(observe_cancel_command))
+    await asyncio.sleep(10)
+
     await api_factory.shutdown()
 
 

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -171,7 +171,7 @@ class APIFactory:
         # Note that this is necessary to start observing
         pr, r = await self._get_response(msg)
 
-        api_command.result = _process_output(r)
+        api_command.result = _process_output(r, api_command.parse_json)
 
         def success_callback(res):
             api_command.result = _process_output(res)

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -8,7 +8,7 @@ class Command(object):
 
     def __init__(self, method, path, data=None, *, parse_json=True,
                  observe=False, observe_duration=0, process_result=None,
-                 err_callback=None):
+                 err_callback=None, observe_cancel=False):
         self._method = method
         self._path = path
         self._data = data
@@ -17,6 +17,7 @@ class Command(object):
         self._err_callback = err_callback
         self._observe = observe
         self._observe_duration = observe_duration
+        self._observe_cancel = observe_cancel
         self._raw_result = None
         self._result = None
 
@@ -52,6 +53,10 @@ class Command(object):
     @property
     def observe_duration(self):
         return self._observe_duration
+
+    @property
+    def observe_cancel(self):
+        return self._observe_cancel
 
     @property
     def raw_result(self):

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -48,7 +48,6 @@ class ApiResource:
                 callback(self)
 
         def error_callback(value):
-            print(value)
             err_callback(self)
 
         self.observe_callback = observe_callback

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -14,6 +14,7 @@ class ApiResource:
     def __init__(self, raw):
         """Initialize base object."""
         self.raw = raw
+        self.observe_callback = None
 
     @property
     def id(self):
@@ -42,11 +43,17 @@ class ApiResource:
 
             Returns a Command.
             """
-            self.raw = value
-            callback(self)
+            if self.raw != value:
+                self.raw = value
+                callback(self)
 
+        def error_callback(value):
+            print(value)
+            err_callback(self)
+
+        self.observe_callback = observe_callback
         return Command('get', self.path, process_result=observe_callback,
-                       err_callback=err_callback,
+                       err_callback=error_callback,
                        observe=True,
                        observe_duration=duration)
 
@@ -72,4 +79,8 @@ class ApiResource:
         """
         def process_result(result):
             self.raw = result
+
+            if self.observe_callback is not None:
+                self.observe_callback()
+
         return Command('get', self.path, process_result=process_result)

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -56,6 +56,9 @@ class ApiResource:
                        observe=True,
                        observe_duration=duration)
 
+    def observe_cancel(self):
+        return Command('get', self.path, observe_cancel=True)
+
     def set_name(self, name):
         """Set group name."""
         return self.set_values({

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -16,6 +16,7 @@ def test_property_access():
                       parse_json=True,
                       observe=False,
                       observe_duration=0,
+                      observe_cancel=False,
                       process_result=pr,
                       err_callback=ec)
 
@@ -24,6 +25,7 @@ def test_property_access():
     assert command.parse_json is True
     assert command.observe is False
     assert command.observe_duration == 0
+    assert command.observe_cancel is False
     assert command.process_result == pr
     assert command.err_callback == ec
 


### PR DESCRIPTION
This change fixes a very small bug (I suppose) in the `aiocoap_api` class
where the flag whether to parse the output as json was not there in the
observe method. Hopefully this makes this part of the API a bit more stable.

Also I've added an observation callback as a global variable in the
`ApiResource` class. When tracking this value for an object, it is possible
to invoke the callback manually. This way the observation can also be
invoked when the user makes a manual change. Thus don't having the need to
call out the observation.

Thirdly I've added an explicit error callback to the `ApiResource` observation
which can be used to diagnose issues easily with the use of the print function.

Finally I've also added a check to check whether or not the incoming result has
even changed from the already existing result. Thus eliminating the need to
continiously update the value. This can hopefully make some parts of the
library a little more stable, because it will limit callback calls.

In conclusion, these are very minor changes, but hopefully will make the
library and in turn the applications using this library a little bit more
stable.