### PR TITLE
Resets an observation when a CHANGED is received

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -145,7 +145,7 @@ class APIFactory:
 
         _, res = await self._get_response(msg)
 
-        api_command.result = _process_output(res, parse_json)
+        api_command.result, _ = _process_output(res, parse_json)
 
         return api_command.result
 
@@ -171,10 +171,12 @@ class APIFactory:
         # Note that this is necessary to start observing
         pr, r = await self._get_response(msg)
 
-        api_command.result = _process_output(r)
+        api_command.result, _ = _process_output(r)
 
         def success_callback(res):
-            api_command.result = _process_output(res)
+            api_command.result, code = _process_output(res)
+            if code == Code.CHANGED:
+                api_command.observe_reset()
 
         def error_callback(ex):
             err_callback(ex)
@@ -223,4 +225,4 @@ def _process_output(res, parse_json=True):
     if not parse_json:
         return output
 
-    return json.loads(output)
+    return json.loads(output), res.code

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -1,6 +1,7 @@
 """Command implementation."""
 
 from copy import deepcopy
+from .error import ObservationError
 
 
 class Command(object):
@@ -68,6 +69,9 @@ class Command(object):
             self._result = self._process_result(value)
 
         self._raw_result = value
+
+    def observe_reset(self):
+        self.err_callback(ObservationError())
 
     def url(self, host):
         """Generate url for coap client."""

--- a/pytradfri/error.py
+++ b/pytradfri/error.py
@@ -35,3 +35,12 @@ class ServerError(RequestError):
     See section 5.9.3 of draft-ietf-core-coap-04.
     """
     pass
+
+
+class ObservationError():
+    """Error when the observation got stuck.
+
+    This can happen with indefinate observations which can get stuck after
+    some time.
+    """
+    pass


### PR DESCRIPTION
It seems that the `pytradfri` lib tends to get stuck on observations for
some people. This change will throw an Error when a CHANGED message is
received. According to some users they only receive these messages when
the observation is in a stuck state.

When implemented correctly - which it is on `example_async.py` - the
observation will restart. I tried this myself by forcing a reset of an
observation after 5 messages and that seems to work beautifully.

Feedback is appreciated!