### PR TITLE
[./dev_docker] fix TZ issue for docker on mac

### DIFF
--- a/script/dev_docker
+++ b/script/dev_docker
@@ -28,6 +28,15 @@ then
     -v `pwd`:/usr/src/app \
     --rm \
     -t -i tradfri-dev bash
+elif [ "$(uname)" = "Darwin" ] && [ $# -eq 0 ]
+then
+  OSX_TZ=$(ls -la /etc/localtime | cut -d/ -f8-9)
+  docker run \
+    --net=host \
+    -e "TZ=$OSX_TZ" \
+    -v `pwd`:/usr/src/app \
+    --rm \
+    -t -i tradfri-dev bash
 else
   docker run \
     --net=host \


### PR DESCRIPTION
When TZ is not explicitly specified, docker on mac throws up this nice error by default:
```
docker: Error response from daemon: Mounts denied:
The path /etc/localtime
is not shared from OS X and is not known to Docker.
You can configure shared paths from Docker -> Preferences... -> File Sharing.
See https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.
```
Refer this upstream docker for-mac upstream issue for details: https://github.com/docker/for-mac/issues/2396
This tiny improvement makes onboarding easier for mac folks who don't want to install libcoap maybe?