### PR TITLE
aiocoap_api: prevent race in _reset_protocol

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -41,7 +41,7 @@ class APIFactory:
         if self._loop is None:
             self._loop = asyncio.get_event_loop()
 
-        self._reset_lock = asyncio.Lock(loop=self._loop)
+        self._reset_lock = asyncio.Lock()
 
         PatchedDTLSSecurityStore.IDENTITY = self._psk_id.encode('utf-8')
 


### PR DESCRIPTION
When multiple concurrent requests fail at the same time, (for
example when the gateway is unavailable), they will try to reset
the underlying aiocoap Protocol.  This reset operation is not
async-safe and a race condition may be triggered.

This commit marks APIFactory._reset_protocol as a critical section
and introduces a lock for preventing concurrent execution.

---

### Example traceback:

<details>
<summary>AttributeError: 'NoneType' object has no attribute 'values'</summary>

```
Traceback (most recent call last):
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/pytradfri/api/aiocoap_api.py", line 95, in _get_response
    r = await pr.response
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/aiocoap/protocol.py", line 816, in _run_outer
    yield from cls._run(app_request, response, weak_observation, protocol, log, exchange_monitor_factory)
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/aiocoap/protocol.py", line 865, in _run
    blockresponse = yield from blockrequest.response
aiocoap.error.RequestTimedOut

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./tfcd.py", line 286, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 612, in run_until_complete
    return future.result()
  File "./tfcd.py", line 279, in main
    raise e
  File "./tfcd.py", line 244, in main
    await api(commands)
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/pytradfri/api/aiocoap_api.py", line 159, in request
    command_results = await asyncio.gather(*commands, loop=self._loop)
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/pytradfri/api/aiocoap_api.py", line 146, in _execute
    _, res = await self._get_response(msg)
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/pytradfri/api/aiocoap_api.py", line 100, in _get_response
    await self._reset_protocol(e)
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/pytradfri/api/aiocoap_api.py", line 78, in _reset_protocol
    await protocol.shutdown()
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/aiocoap/protocol.py", line 133, in shutdown
    for exchange_monitor, cancellable in self._active_exchanges.values():
AttributeError: 'NoneType' object has no attribute 'values'
```
</details>

### After fix:

<details>
<summary>pytradfri.error.RequestTimeout: ('Request timed out.', RequestTimedOut())</summary>

```
Traceback (most recent call last):
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/pytradfri/api/aiocoap_api.py", line 98, in _get_response
    r = await pr.response
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/aiocoap/protocol.py", line 816, in _run_outer
    yield from cls._run(app_request, response, weak_observation, protocol, log, exchange_monitor_factory)
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/aiocoap/protocol.py", line 865, in _run
    blockresponse = yield from blockrequest.response
aiocoap.error.RequestTimedOut

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./tfcd.py", line 286, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 612, in run_until_complete
    return future.result()
  File "./tfcd.py", line 279, in main
    raise e
  File "./tfcd.py", line 244, in main
    await api(commands)
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/pytradfri/api/aiocoap_api.py", line 162, in request
    command_results = await asyncio.gather(*commands, loop=self._loop)
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/pytradfri/api/aiocoap_api.py", line 149, in _execute
    _, res = await self._get_response(msg)
  File "/home/daan/Documents/Code/tfcd/.env/lib/python3.8/site-packages/pytradfri/api/aiocoap_api.py", line 104, in _get_response
    raise RequestTimeout('Request timed out.', e)
pytradfri.error.RequestTimeout: ('Request timed out.', RequestTimedOut())
```
</details>

Cc @marrit-git