### PR TITLE
Upgrade to aiocoap 0.4b3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 pip-selfcheck.json
 # Python stuff
 *.py[cod]
+venv
 
 # IDE stuff
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,10 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - python: "3.5"
-      env: TOXENV=py35
-    - python: "3.6"
-      env: TOXENV=py36
     - python: "3.7"
       env: TOXENV=py37
-      dist: xenial
-      sudo: true
-    - python: "3.8-dev"
+    - python: "3.8"
       env: TOXENV=py38
-      dist: xenial
-      sudo: true
-  allow_failures:
-    - python: "3.7" #Cython doesn't support 3.7 yet.
-      env: TOXENV=py37
-      dist: xenial
-      sudo: true #workaround for #travis-ci/travis-ci#9815
-    - python: "3.8-dev"
-      env: TOXENV=py38
-      dist: xenial
-      sudo: true #workaround for travis-ci/travis-ci#9815
 cache:
   directories:
     - $HOME/.cache/pip

--- a/examples/debug_info.py
+++ b/examples/debug_info.py
@@ -125,8 +125,8 @@ def print_lamps():
         exit(bold("No lamps paired"))
 
     container = []
-    for l in lights:
-        container.append(l.raw)
+    for light in lights:
+        container.append(light.raw)
     print(jsonify(container))
 
 

--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -56,7 +56,8 @@ async def run():
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity,
+                                            psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
         api_factory = await APIFactory.init(host=args.host, psk_id=identity)

--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -56,10 +56,10 @@ async def run():
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = APIFactory(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
-        api_factory = APIFactory(host=args.host, psk_id=identity)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity)
 
         try:
             psk = await api_factory.generate_psk(args.key)

--- a/examples/example_color.py
+++ b/examples/example_color.py
@@ -72,7 +72,8 @@ async def run():
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity,
+                                            psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
         api_factory = await APIFactory.init(host=args.host, psk_id=identity)

--- a/examples/example_color.py
+++ b/examples/example_color.py
@@ -72,10 +72,10 @@ async def run():
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = APIFactory(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
-        api_factory = APIFactory(host=args.host, psk_id=identity)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity)
 
         try:
             psk = await api_factory.generate_psk(args.key)

--- a/examples/example_cover_async.py
+++ b/examples/example_cover_async.py
@@ -55,7 +55,8 @@ async def run():
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity,
+                                            psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
         api_factory = await APIFactory.init(host=args.host, psk_id=identity)

--- a/examples/example_cover_async.py
+++ b/examples/example_cover_async.py
@@ -55,10 +55,10 @@ async def run():
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = APIFactory(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
-        api_factory = APIFactory(host=args.host, psk_id=identity)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity)
 
         try:
             psk = await api_factory.generate_psk(args.key)

--- a/examples/example_pair.py
+++ b/examples/example_pair.py
@@ -62,10 +62,10 @@ async def run(shutdown):
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = APIFactory(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
-        api_factory = APIFactory(host=args.host, psk_id=identity)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity)
 
         try:
             psk = await api_factory.generate_psk(args.key)

--- a/examples/example_pair.py
+++ b/examples/example_pair.py
@@ -62,7 +62,8 @@ async def run(shutdown):
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity,
+                                            psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
         api_factory = await APIFactory.init(host=args.host, psk_id=identity)

--- a/examples/example_socket_async.py
+++ b/examples/example_socket_async.py
@@ -55,7 +55,8 @@ async def run():
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity,
+                                            psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
         api_factory = await APIFactory.init(host=args.host, psk_id=identity)

--- a/examples/example_socket_async.py
+++ b/examples/example_socket_async.py
@@ -55,10 +55,10 @@ async def run():
     try:
         identity = conf[args.host].get('identity')
         psk = conf[args.host].get('key')
-        api_factory = APIFactory(host=args.host, psk_id=identity, psk=psk)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity, psk=psk)
     except KeyError:
         identity = uuid.uuid4().hex
-        api_factory = APIFactory(host=args.host, psk_id=identity)
+        api_factory = await APIFactory.init(host=args.host, psk_id=identity)
 
         try:
             psk = await api_factory.generate_psk(args.key)

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -202,8 +202,9 @@ class APIFactory:
 
         return self._psk
 
-    async def _update_credentials(self, protocol):
+    async def _update_credentials(self):
         """Update credentials."""
+        protocol = await self._get_protocol()
         protocol.client_credentials.load_from_dict({
             f"coaps://{self._host}:5684/*": {
                 "dtls": {

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -16,7 +16,8 @@ _SENTINEL = object()
 
 
 class APIFactory:
-    def __init__(self, host: str, psk_id='pytradfri', psk=None, internal_create=None):
+    def __init__(self, host: str, psk_id='pytradfri', psk=None,
+                 internal_create=None):
         if internal_create is not _SENTINEL:
             raise ValueError("Use APIFactory.init(…) to initialize APIFactory")
 
@@ -149,7 +150,7 @@ class APIFactory:
             return result
 
         commands = (self._execute(api_command) for api_command in api_commands)
-        command_results = await asyncio.gather(*commands, loop=self._loop)
+        command_results = await asyncio.gather(*commands)
 
         return command_results
 
@@ -184,7 +185,7 @@ class APIFactory:
             protocol = await self._get_protocol()
             command = Gateway().generate_psk(self._psk_id)
             protocol.client_credentials.load_from_dict({
-                f"coaps://{self._host}:5684/{command.path}": {
+                f"coaps://{self._host}:5684/{command.path_str}": {
                     "dtls": {
                         "psk": security_key.encode('utf-8'),
                         'client-identity': 'Client_identity'.encode('utf-8')

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -47,7 +47,7 @@ class APIFactory:
     async def _get_protocol(self):
         """Get the protocol for the request."""
         if self._protocol is None:
-            self._protocol = asyncio.Task(Context.create_client_context())
+            self._protocol = asyncio.create_task(Context.create_client_context())
         return (await self._protocol)
 
     async def _reset_protocol(self, exc=None):

--- a/pytradfri/api/libcoap_api.py
+++ b/pytradfri/api/libcoap_api.py
@@ -124,7 +124,7 @@ class APIFactory:
             proc = subprocess.Popen(command, **kwargs)
         except subprocess.CalledProcessError as err:
             raise RequestError(
-                'Error executing request: %s'.format(err)) from None
+                'Error executing request: {}'.format(err)) from None
 
         output = ''
         open_obj = 0

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -69,10 +69,14 @@ class Command(object):
 
         self._raw_result = value
 
+    @property
+    def path(self) -> str:
+        """Return coap path."""
+        return '/'.join(str(v) for v in self._path)
+
     def url(self, host):
         """Generate url for coap client."""
-        path = '/'.join(str(v) for v in self._path)
-        return 'coaps://{}:5684/{}'.format(host, path)
+        return 'coaps://{}:5684/{}'.format(host, self.path)
 
     def _merge(self, a, b):
         """Merges a into b."""

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -70,13 +70,13 @@ class Command(object):
         self._raw_result = value
 
     @property
-    def path(self) -> str:
+    def path_str(self) -> str:
         """Return coap path."""
         return '/'.join(str(v) for v in self._path)
 
     def url(self, host):
         """Generate url for coap client."""
-        return 'coaps://{}:5684/{}'.format(host, self.path)
+        return 'coaps://{}:5684/{}'.format(host, self.path_str)
 
     def _merge(self, a, b):
         """Merges a into b."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiocoap==0.4a1
-DTLSSocket==0.1.7
-typing>=3,<4
+aiocoap==0.4b3
+DTLSSocket==0.1.10
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,19 @@ testpaths = tests
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build,setup.py
+doctests = True
+# To work with Black
+max-line-length = 88
+# E501: line too long
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+# W504 line break after binary operator
+# E402 import at top (for examples)
+ignore =
+    E501,
+    W503,
+    E203,
+    D202,
+    W504,
+    E402

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ DOWNLOAD_URL = \
     'https://github.com/ggravlingen/pytradfri/archive/{}.zip'.format(VERSION)
 
 EXTRAS_REQUIRE = {
-    'async': ['aiocoap==0.4a1', 'DTLSSocket==0.1.7']
+    'async': ['aiocoap==0.4b3', 'DTLSSocket==0.1.10']
 }
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])

--- a/tests/api/test_aiocoap_api.py
+++ b/tests/api/test_aiocoap_api.py
@@ -44,7 +44,7 @@ class MockContext:
         return MockProtocol()
 
 
-async def mock_create_context(loop):
+async def mock_create_context():
     return MockContext()
 
 
@@ -53,7 +53,7 @@ async def test_request_returns_single(monkeypatch):
     monkeypatch.setattr('aiocoap.Context.create_client_context',
                         mock_create_context)
 
-    api = APIFactory('127.0.0.1').request
+    api = (await APIFactory.init('127.0.0.1')).request
 
     command = Command('', '')
 
@@ -67,7 +67,7 @@ async def test_request_returns_list(monkeypatch):
     monkeypatch.setattr('aiocoap.Context.create_client_context',
                         mock_create_context)
 
-    api = APIFactory('127.0.0.1').request
+    api = (await APIFactory.init('127.0.0.1')).request
 
     command = Command('', '')
 


### PR DESCRIPTION
This upgrades pytradfri to use aiocoap 0.4b3 and migrates credential management to the new approach.

I don't have a Tradfri gateway here so I only got as far as that aiocoap was able to find the credentials. Was not able to verify. 

Fixes #185

Can be tested using:

```
python3 examples/example_async.py <IP> -K <KEY ON BOTTOM OF GATEWAY>
```

This is a breaking change. Async API Factory now needs to be set using `await APIFActory.init(…)`